### PR TITLE
Reconcile branch styling with feature baseline

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4,8 +4,8 @@
 }
 
 ::selection {
-  background-color: #6ed3d0;
-  color: white;
+  background-color: #88fbd7;
+  color: aliceblue;
 }
 
 .item {


### PR DESCRIPTION
### Motivation
- Resolver una discrepancia de estilo entre ramas donde la rama `feature` (publicada en GitHub Pages) es la fuente de verdad para la apariencia visual.
- Asegurar que la selección de texto muestre el mismo aspecto en la rama de trabajo que en la rama `feature` para mantener coherencia en producción.

### Description
- Restauré las reglas de `::selection` en `css/style.css` para que `background-color` sea `#88fbd7` y `color` sea `aliceblue`.
- El cambio está limitado a un único archivo: `css/style.css` y afecta únicamente a las dos propiedades mencionadas.
- Los cambios se aplicaron en el repositorio local y la diferencia fue verificada contra la versión de referencia.

### Testing
- No se ejecutaron pruebas automatizadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d6a8ecd6c483258f381e083464a1e9)