### PR TITLE
Rebrand site to Senior Software Engineer: add Experience, update copy/projects/skills, and tweak animated phrases

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -163,6 +163,18 @@ a.navbar-item:hover {
   background: black url(../assets/easyweather.jpg) center / cover;
 }
 
+.tunecore-bg {
+  background: linear-gradient(rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0.35)), url('https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=1400&q=80') center / cover;
+}
+
+.pluginuseful-bg {
+  background: linear-gradient(rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0.35)), url('https://images.unsplash.com/photo-1461749280684-dccba630e2f6?auto=format&fit=crop&w=1400&q=80') center / cover;
+}
+
+.globant-bg {
+  background: linear-gradient(rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0.35)), url('https://images.unsplash.com/photo-1451187580459-43490279c0fa?auto=format&fit=crop&w=1400&q=80') center / cover;
+}
+
 .p-project {
   background: rgba(51, 51, 51, 0.2);
 }

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
       <div class="columns mt-5 mx-1">
         <div class="column card compailer">
           <h2 class="is-size-4 is-size-5-mobile mb-2 has-text-weight-semibold pl-2">TuneCore - Artist Platform Reliability</h2>
-          <div class="image sustyle image-card is-16by9">
+          <div class="image tunecore-bg image-card is-16by9">
             <p class="has-text-white pl-3 has-text-weight-semibold p-project is-size-6-mobile ">Case study on scaling backend services that power artist distribution workflows, improving platform reliability, and supporting cross-functional delivery across product and engineering teams.</p>
           </div>
           <footer class="card-footer">
@@ -105,7 +105,7 @@
       <div class="columns mt-5 mx-1">
         <div class="column card compailer">
           <h2 class="is-size-4 is-size-5-mobile mb-2 has-text-weight-semibold pl-2">Plug in Useful - Integrations and Product Delivery</h2>
-          <div class="image IK image-card is-16by9">
+          <div class="image pluginuseful-bg image-card is-16by9">
             <p class="has-text-white pl-3 has-text-weight-semibold p-project">Case study on building and extending backend integrations, collaborating with product stakeholders, and shipping maintainable features with a strong quality and ownership mindset.</p>
           </div>
           <footer class="card-footer">
@@ -119,7 +119,7 @@
       <div class="columns mt-5 mx-1">
         <div class="column card compailer">
           <h2 class="is-size-4 is-size-5-mobile mb-2 has-text-weight-semibold pl-2">Globant - Enterprise Platform Engineering</h2>
-          <div class="image private image-card is-16by9">
+          <div class="image globant-bg image-card is-16by9">
             <p class="has-text-white pl-3 has-text-weight-semibold p-project">Case study on delivering backend solutions in enterprise environments, improving engineering practices, and contributing to scalable systems with strong collaboration across distributed teams.</p>
           </div>
           <footer class="card-footer">

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
         <div class="mt-2 is-transparent" aria-label="main navigation">
           <a class="item ml-4" href="#home">home</a>
           <a class="item ml-3" href="#work">work</a>
+          <a class="item ml-3" href="#experience">experience</a>
           <a class="item ml-3" href="#about">about</a>
           <a class="item ml-3" href="#contact">contact</a>
         </div>
@@ -38,6 +39,7 @@
           <div class="menu mt-2 is-transparent" aria-label="main navigation">
             <a class="navbar-item pb-0" href="#home">home</a>
             <a class="navbar-item py-0" href="#work">work</a>
+            <a class="navbar-item py-0" href="#experience">experience</a>
             <a class="navbar-item py-0" href="#about">about</a>
             <a class="navbar-item py-0" href="#contact">contact</a>
           </div>
@@ -49,20 +51,20 @@
     <div class="columns mt-3">
       <div class="column">
         <h1 class="subtitle is-size-4 is-size-3-widescreen is-size-5-mobile has-text-centered">
-          I'm <span class="has-text-weight-bold">Miguel Ricaño,</span> and I create <span class="has-text-weight-bold text space2">solutions.</span>
+          I'm <span class="has-text-weight-bold">Miguel Ricaño,</span> a <span class="has-text-weight-bold">Senior Software Engineer</span> focused on building reliable <span class="has-text-weight-bold text space2">backend and platform systems.</span>
         </h1>
         <div class="front-text">
           <div class="has-text-centered hero-text">
-            FRONT-END
+            BACKEND
           </div>
           <div class="has-text-centered hero-text">
-            BACK-END
+            PLATFORM
           </div>
           <div class="has-text-centered hero-text">
-            SHOPIFY-EXPERT
+            DISTRIBUTED SYSTEMS
           </div>
           <div class="has-text-centered txt hero-text">
-            DEVELOPMENT
+            ENGINEERING
           </div>
           <div class="has-text-centered mt-5">
             <a href="https://github.com/mricanho" target="_blank" rel="noopener noreferrer">
@@ -85,65 +87,80 @@
   </section> 
   <section class="section pt-1 work-s" id="work">
     <div class="container big-container">
-      <h1 class="title is-size-3 is-size-4-mobile txt title-x pb-5">#Cool-Works</h1>
+      <h1 class="title is-size-3 is-size-4-mobile txt title-x pb-5">#Case-Studies</h1>
       <div class="columns mt-5 mx-1">
         <div class="column card compailer">
-          <h2 class="is-size-4 is-size-5-mobile mb-2 has-text-weight-semibold pl-2">Sustyle</h2>
+          <h2 class="is-size-4 is-size-5-mobile mb-2 has-text-weight-semibold pl-2">TuneCore - Artist Platform Reliability</h2>
           <div class="image sustyle image-card is-16by9">
-            <p class="has-text-white pl-3 has-text-weight-semibold p-project is-size-6-mobile ">MVP website focused on the latest sustainability articles. HTML5, CSS3, and Bulma for the front-end, and Ruby, Ruby on Rails for the back-end, as well as PostgresSQL for the DB.</p>
+            <p class="has-text-white pl-3 has-text-weight-semibold p-project is-size-6-mobile ">Case study on scaling backend services that power artist distribution workflows, improving platform reliability, and supporting cross-functional delivery across product and engineering teams.</p>
           </div>
           <footer class="card-footer">
-            <a href="https://github.com/mricanho/Sustyle" class="card-footer-item" target="_blank" rel="noopener noreferrer">
+            <a href="https://www.tunecore.com/" class="card-footer-item" target="_blank" rel="noopener noreferrer">
               <img src="./dist/assets/github.png" alt="github icon" class="front-icon-projects" id="p1">
             </a>
-            <a href="https://sustyle.herokuapp.com/" class="card-footer-item has-text-weight-bold is-size-5 is-size-6-mobile" target="_blank" rel="noopener noreferrer">Live Demo</a>
+            <a href="https://www.tunecore.com/" class="card-footer-item has-text-weight-bold is-size-5 is-size-6-mobile" target="_blank" rel="noopener noreferrer">Company</a>
           </footer>
         </div>
       </div>
       <div class="columns mt-5 mx-1">
         <div class="column card compailer">
-          <h2 class="is-size-4 is-size-5-mobile mb-2 has-text-weight-semibold pl-2">IK Store</h2>
+          <h2 class="is-size-4 is-size-5-mobile mb-2 has-text-weight-semibold pl-2">Plug in Useful - Integrations and Product Delivery</h2>
           <div class="image IK image-card is-16by9">
-            <p class="has-text-white pl-3 has-text-weight-semibold p-project">IK sustainable is a fashion brand, I built their eCommerce in Liquid on Shopify. I designed the template and all the SEO, and create the apps for the website.</p>
+            <p class="has-text-white pl-3 has-text-weight-semibold p-project">Case study on building and extending backend integrations, collaborating with product stakeholders, and shipping maintainable features with a strong quality and ownership mindset.</p>
           </div>
           <footer class="card-footer">
-            <a href="https://www.instagram.com/ik.sustainable/" class="card-footer-item" target="_blank" rel="noopener noreferrer">
+            <a href="https://pluginuseful.com/" class="card-footer-item" target="_blank" rel="noopener noreferrer">
               <img src="./dist/assets/insta.png" alt="insta icon" class="front-icon-projects2">
             </a>
-            <a href="https://ik-store.com/" class="card-footer-item has-text-weight-bold is-size-5 is-size-6-mobile" target="_blank" rel="noopener noreferrer">Live Website</a>
+            <a href="https://pluginuseful.com/" class="card-footer-item has-text-weight-bold is-size-5 is-size-6-mobile" target="_blank" rel="noopener noreferrer">Company</a>
           </footer>
         </div>
       </div>
       <div class="columns mt-5 mx-1">
         <div class="column card compailer">
-          <h2 class="is-size-4 is-size-5-mobile mb-2 has-text-weight-semibold pl-2">Private Events</h2>
+          <h2 class="is-size-4 is-size-5-mobile mb-2 has-text-weight-semibold pl-2">Globant - Enterprise Platform Engineering</h2>
           <div class="image private image-card is-16by9">
-            <p class="has-text-white pl-3 has-text-weight-semibold p-project">Fully functional event website in which users can attend other user's events. I used Ruby on Rails, Ruby, PostgresSQL for the back-end and HTML5, and Bulma for the front-end.</p>
+            <p class="has-text-white pl-3 has-text-weight-semibold p-project">Case study on delivering backend solutions in enterprise environments, improving engineering practices, and contributing to scalable systems with strong collaboration across distributed teams.</p>
           </div>
           <footer class="card-footer">
-            <a href="https://github.com/mricanho/Private-Events" class="card-footer-item" target="_blank" rel="noopener noreferrer">
+            <a href="https://www.globant.com/" class="card-footer-item" target="_blank" rel="noopener noreferrer">
               <img src="./dist/assets/github.png" alt="github icon" class="front-icon-projects">
             </a>
-            <a href="https://murmuring-wildwood-50583.herokuapp.com/" class="card-footer-item has-text-weight-bold is-size-5 is-size-6-mobile" target="_blank" rel="noopener noreferrer">Live Demo</a>
+            <a href="https://www.globant.com/" class="card-footer-item has-text-weight-bold is-size-5 is-size-6-mobile" target="_blank" rel="noopener noreferrer">Company</a>
           </footer>
         </div>
       </div>
       <div class="columns mt-5 mx-1">
         <div class="column card compailer">
-          <h2 class="is-size-4 is-size-5-mobile mb-2 has-text-weight-semibold pl-2">EasyWeather</h2>
+          <h2 class="is-size-4 is-size-5-mobile mb-2 has-text-weight-semibold pl-2">Minimal Audio - Internal Platform Contributions</h2>
           <div class="image easy-weather is-16by9">
-            <p class="has-text-white pl-3 has-text-weight-semibold p-project">I used OpenWeather API to display the temp and conditions of the weather of the desired city. Javascript and Bulma were the tools selected for the front-end as well as webpack.</p>
+            <p class="has-text-white pl-3 has-text-weight-semibold p-project">Case study on backend and platform-focused work supporting product engineering, with emphasis on reliability, developer efficiency, and sustainable long-term architecture decisions.</p>
           </div>
           <footer class="card-footer">
-            <a href="https://github.com/mricanho" class="card-footer-item" target="_blank" rel="noopener noreferrer">
+            <a href="https://www.minimal.audio/" class="card-footer-item" target="_blank" rel="noopener noreferrer">
               <img src="./dist/assets/github.png" alt="github icon" class="front-icon-projects">
             </a>
-            <a href="https://rawcdn.githack.com/mricanho/weather-app/37a319bdc46aeddcc8164359331defec361fd294/dist/index.html" class="card-footer-item has-text-weight-bold is-size-5 is-size-6-mobile" target="_blank" rel="noopener noreferrer">Live Demo</a>
+            <a href="https://www.minimal.audio/" class="card-footer-item has-text-weight-bold is-size-5 is-size-6-mobile" target="_blank" rel="noopener noreferrer">Company</a>
           </footer>
         </div>
       </div>
     </div>
     
+  </section>
+  <section class="section is-medium mt-1" id="experience">
+    <h2 class="title is-size-3 is-size-4-mobile txt title-x pb-5">#Experience</h2>
+    <div class="columns">
+      <div class="column content">
+        <h3 class="is-size-5 has-text-weight-semibold">TuneCore - Senior Software Engineer</h3>
+        <p>Built and evolved backend and platform capabilities to support artist-facing products, reliability goals, and continuous delivery in a high-impact music technology environment.</p>
+
+        <h3 class="is-size-5 has-text-weight-semibold mt-5">Plug in Useful - Senior Software Engineer</h3>
+        <p>Delivered backend integrations and product features end-to-end, partnering with cross-functional teams to ship maintainable, scalable solutions.</p>
+
+        <h3 class="is-size-5 has-text-weight-semibold mt-5">Globant - Software Engineer</h3>
+        <p>Contributed to enterprise software initiatives by designing and implementing robust backend services while improving engineering quality and collaboration practices.</p>
+      </div>
+    </div>
   </section>
   <section class="section is-medium mt-1 about-s" id="about">
     <h2 class="title is-size-3 is-size-4-mobile txt title-x pb-5">#Me</h2>
@@ -152,49 +169,45 @@
         <img src="./assets/miguel-color.jpg" alt="Miguel Ricaño" class="mePhoto" loading="lazy">
       </div>
       <div class="column extract is-flex-desktop content">
-        <p class="is-size-5">Once a <span class="has-text-primary">business entrepreneur</span> and <span class="has-text-primary">business broker</span>, now a <span class="has-text-primary">full-stack developer</span> who loves to find 
-          <span class="has-text-primary">simple solutions</span> to <span class="has-text-primary">complex problems</span>.<br><br>
-          I've been developing digital products and business with a lot of teams for the last <span class="has-text-primary">eleven years</span>, 
-          so not only can I understand solutions from a <span class="has-text-primary">business perspective</span>, but I can also now develop solutions from a <span class="has-text-primary">technical perspective</span>: the best of both worlds.<br> 
-          I’m a team player--<span class="has-text-primary">I know that the progress of a project can only be achieved if all the people involved work harmonically</span>, but I can also front solo projects without hesitating.<br> <br>
-          <span class="has-text-primary">Clean code</span> and <span class="has-text-primary">user experience</span> are a must for me, fluent in <span class="has-text-primary">multiple languages</span>, <span class="has-text-primary">frameworks</span>, and <span class="has-text-primary">technologies</span>, and capable of ramping up quickly and efficiently.</p>
+        <p class="is-size-5">I am a <span class="has-text-primary">Senior Software Engineer</span> focused on <span class="has-text-primary">backend and platform engineering</span>.<br><br>
+          I design and build systems that are <span class="has-text-primary">reliable</span>, <span class="has-text-primary">scalable</span>, and <span class="has-text-primary">maintainable</span>, with a strong emphasis on engineering quality, observability, and long-term product velocity.<br><br>
+          My experience spans music-tech and enterprise environments where I partner closely with product, design, and engineering teams to deliver outcomes that improve developer workflows and user impact.<br><br>
+          I care deeply about <span class="has-text-primary">clean architecture</span>, <span class="has-text-primary">clear communication</span>, and <span class="has-text-primary">mentoring</span> teams through complex technical decisions.</p>
       </div>
     </div>
     <div class="columns mt-6 px-6 is-align-items-center">
       <div class="column skills mt-6">
         <div class="columns is-flex-desktop-only is-flex-direction-row">      
           <div class="column content zborder mb-3">
-            <h2 class="is-size-6 skill-h has-text-centered has-text-white">Languages</h2>
+            <h2 class="is-size-6 skill-h has-text-centered has-text-white">Backend</h2>
             <ul class="has-text-centered">
               <li>Ruby</li>
-              <li>HTML5/CSS3</li>
-              <li>Javascript ES6</li>
-              <li>Kotlin</li>
+              <li>JavaScript / TypeScript</li>
+              <li>REST APIs</li>
+              <li>Service Design</li>
             </ul>
 
           </div>
           <div class="column content zborder mb-3">
-            <h2 class="is-size-6 has-text-centered skill-h has-text-white">Frameworks</h2>
+            <h2 class="is-size-6 has-text-centered skill-h has-text-white">Platform & Cloud</h2>
             <ul class="has-text-centered">
               <li>Ruby on Rails</li>
-              <li>Bootstrap</li>
-              <li>Bulma</li>
-              <li>Liquid</li>
-              <li>React/Redux</li>
+              <li>CI/CD</li>
+              <li>Docker</li>
+              <li>Monitoring & Observability</li>
+              <li>Performance Optimization</li>
             </ul>
             
           </div>
           <div class="column content zborder">
-            <h2 class="is-size-6 has-text-centered skill-h has-text-white">Skills</h2>
+            <h2 class="is-size-6 has-text-centered skill-h has-text-white">Data & Delivery</h2>
             <ul class="has-text-centered">
-              <li>Git</li>
-              <li>PostgresSQL</li>
-              <li>Github</li>
-              <li>Heroku</li>
-              <li>TDD</li>
-              <li>Responsive</li>
-              <li>Rspec</li>
-              <li>Remote Pair-Programming</li>
+              <li>PostgreSQL</li>
+              <li>Testing (TDD)</li>
+              <li>Git & GitHub</li>
+              <li>Agile Delivery</li>
+              <li>Technical Leadership</li>
+              <li>Cross-functional Collaboration</li>
             </ul>
             
           </div>
@@ -224,7 +237,7 @@
         <footer class="card-footer">
           <p class="card-footer-item">
             <span>
-              Download my <a href="./dist/assets/Resume.pdf" download="Miguel-Ricaño-Resume"><span class="has-background-primary has-text-primary-light">Resume</span></a>
+              Download my <a href="./dist/assets/Senior Software Engineer - Miguel Ricaño.pdf" download="Senior-Software-Engineer-Miguel-Ricano"><span class="has-background-primary has-text-primary-light">Resume</span></a>
             </span>
           </p>
           <p class="card-footer-item">

--- a/index.html
+++ b/index.html
@@ -130,20 +130,6 @@
           </footer>
         </div>
       </div>
-      <div class="columns mt-5 mx-1">
-        <div class="column card compailer">
-          <h2 class="is-size-4 is-size-5-mobile mb-2 has-text-weight-semibold pl-2">Minimal Audio - Internal Platform Contributions</h2>
-          <div class="image easy-weather is-16by9">
-            <p class="has-text-white pl-3 has-text-weight-semibold p-project">Case study on backend and platform-focused work supporting product engineering, with emphasis on reliability, developer efficiency, and sustainable long-term architecture decisions.</p>
-          </div>
-          <footer class="card-footer">
-            <a href="https://www.minimal.audio/" class="card-footer-item" target="_blank" rel="noopener noreferrer">
-              <img src="./dist/assets/github.png" alt="github icon" class="front-icon-projects">
-            </a>
-            <a href="https://www.minimal.audio/" class="card-footer-item has-text-weight-bold is-size-5 is-size-6-mobile" target="_blank" rel="noopener noreferrer">Company</a>
-          </footer>
-        </div>
-      </div>
     </div>
     
   </section>

--- a/js/myscript.js
+++ b/js/myscript.js
@@ -61,11 +61,11 @@ class TextScramble {
 }
 
 const phrases = [
-  'web-apps.',
-  'websites.',
-  'databases.',
-  'e-commerce.',
-  'solutions.',
+  'platform systems.',
+  'backend services.',
+  'distributed architectures.',
+  'developer productivity.',
+  'reliable solutions.',
 ];
 
 const el = document.querySelector('.text');


### PR DESCRIPTION
### Motivation
- Reposition the personal website to reflect a Senior Software Engineer / backend & platform focus and highlight relevant experience and case studies.
- Improve clarity of professional summary, skills, and project descriptions to better match platform engineering and distributed-systems work.

### Description
- Added an `#experience` nav item and new `#experience` section with entries for TuneCore, Plug in Useful, and Globant. 
- Updated hero copy to `Senior Software Engineer` and replaced the rotating front-end text with backend/platform-oriented terms by changing the `phrases` array in `js/myscript.js`.
- Renamed `#Cool-Works` to `#Case-Studies`, replaced individual project titles and descriptions with company/case-study links, and updated card footer links to point to company sites.
- Revised the `#about` section copy and restructured skills columns by renaming headings to `Backend`, `Platform & Cloud`, and `Data & Delivery` and updating list items accordingly, and replaced the resume download link to the new senior-level PDF filename.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d6c796a7c083259848403720c57e1b)